### PR TITLE
Fix per-module loglevel configuration (Apache 2.4)

### DIFF
--- a/src/mod_maxminddb.c
+++ b/src/mod_maxminddb.c
@@ -29,6 +29,10 @@
 #include <maxminddb.h>
 #include <inttypes.h>
 
+#ifdef APLOG_USE_MODULE
+APLOG_USE_MODULE(maxminddb);
+#endif
+
 #if defined (MAXMINDDB_DEBUG)
 #define INFO(server_rec, ...)                                            \
     ap_log_error(APLOG_MARK, APLOG_DEBUG | APLOG_NOERRNO, 0, server_rec, \


### PR DESCRIPTION
In Apache 2.4 you can configure the log level on a per-module granularity.
This only requires the use of the APLOG_USE_MODULE macro inside the Apache
module.

This commit fixes the per-module loglevel configuration for mod_maxminddb.
You can now configure

    LogLevel maxminddb:debug

which will cause mod_maxminddb to generate debug messages in the general Apache
error_log file, even if debug level logging is turned off everywhere else.

Further reading:
https://httpd.apache.org/docs/2.4/developer/new_api_2_4.html#upgrading