### PR TITLE
Add ability to override the name of the MMDB_ADDR environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ This directive enables or disables the MaxMind DB lookup. Valid settings are
 
     MaxMindDBEnable On
 
+### `MaxMindDBAddrEnv` ###
+
+While this environment variable is primarily intended for debugging purposes, 
+this directive allows you to set the name of the environment variable which
+contains the IP address used for lookups. By default, this is set to
+`MMDB_ADDR`, but can be overridden in the event you need to support older
+codebases which used the deprecated `GEOIP_ADDR`. 
+
+    MaxMindDBAddrEnv MMDB_ADDR
+
 ### `MaxMindDBFile` ###
 
 This directive associates a name placeholder with a MaxMind DB file on the
@@ -90,9 +100,8 @@ using map keys or 0-based array indexes separated by `/`.
 
 ## Exported Environment Variables ##
 
-In addition to the environment variable specified by `MaxMindDBEnv`, this
-module exports `MMDB_ADDR`, which contains the IP address used for lookups by
-the module. This is primarily intended for debugging purposes.
+This module exports only those environment variables specified by the
+`MaxMindDBEnv` and  `MaxMindDBAddrEnv` directives.
 
 ## Examples ##
 

--- a/src/mod_maxminddb.c
+++ b/src/mod_maxminddb.c
@@ -173,6 +173,10 @@ static void *merge_config(apr_pool_t *pool, void *parent, void *child)
     conf->enabled = child_conf->enabled == -1 ?
                     parent_conf->enabled : child_conf->enabled;
 
+    conf->mmdb_addr_env_var = (NULL == child_conf->mmdb_addr_env_var)
+                    ? parent_conf->mmdb_addr_env_var
+                    : child_conf->mmdb_addr_env_var;
+
     conf->databases = apr_hash_overlay(pool, child_conf->databases,
                                        parent_conf->databases);
     conf->lookups = apr_hash_merge(pool, child_conf->lookups,

--- a/src/mod_maxminddb.c
+++ b/src/mod_maxminddb.c
@@ -85,6 +85,8 @@ static void export_env_for_lookups(request_rec *r, const char *ip_address,
                                    MMDB_lookup_result_s *lookup_result,
                                    apr_hash_t *lookups_for_db);
 static const char *set_maxminddb_enable(cmd_parms *cmd, void *config, int arg);
+static const char *set_maxminddb_addr_env(cmd_parms *cmd, void *dir_config,
+                                     const char *env);
 static const char *set_maxminddb_env(cmd_parms *cmd, void *config,
                                      const char *env, const char *path);
 static const char *set_maxminddb_filename(cmd_parms *cmd, void *config,


### PR DESCRIPTION
While the MMDB_ADDR environment variable is primarily intended for debugging purposes, this directive allows you to set the name of the environment variable which contains the IP address used for lookups via MaxMindDBAddrEnv. By default, this is set to MMDB_ADDR, but it can be overridden in the event you need to support large, older codebases which relied on the deprecated GEOIP_ADDR.
