### PR TITLE
fix display problems and add note for Apache 2.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ This example shows how to block users based on their country:
     SetEnvIf MM_COUNTRY_CODE ^(RU|DE|FR) BlockCountry
     Deny from env=BlockCountry
 
-Note that at least the "Deny" (or "Allow") action must be applied within a
-<Directory>, <Location> or <Files> container.
+Note that at least the "Deny" or "Allow" directive (or "Require" directive in
+Apache 2.4 and above) must be applied within a `<Directory>`, `<Location>` or
+`<Files>` container.
 
 ## Data Output Format ##
 


### PR DESCRIPTION
Tags introduced in merge#50 were not correctly displayed on web page because they were not quoted. Additionally, a remark about the new access control framework introduced in Apache 2.4 is in order.