### PR TITLE
Allow to set IP address to analyze

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ you want. If you need to use an IP address specified in a header (e.g., by
 your proxy frontend),
 [mod_remoteip](http://httpd.apache.org/docs/current/mod/mod_remoteip.html) may
 be used to set the client IP address.
+Manually setting the client IP address is also possible - see
+[Client IP address lookup control](client-ip-address-lookup-control).
 
 ## Directives ##
 
@@ -93,6 +95,17 @@ using map keys or 0-based array indexes separated by `/`.
 In addition to the environment variable specified by `MaxMindDBEnv`, this
 module exports `MMDB_ADDR`, which contains the IP address used for lookups by
 the module. This is primarily intended for debugging purposes.
+
+## Client IP address lookup control ##
+
+In case you want supply your own value for the IP address to lookup, it may be
+done by setting the environment variable `MMDB_ADDR`.
+This can be done, for instance, with
+[ModSecurity](https://github.com/SpiderLabs/ModSecurity/) in (real) phase 1.
+Note that mod_setenvif and mod_rewrite cannot be used for this as they are
+running after this module. For most usages,
+[mod_remoteip](http://httpd.apache.org/docs/current/mod/mod_remoteip.html)
+is an easier alternative.
 
 ## Examples ##
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ In case you want supply your own value for the IP address to lookup, it may be
 done by setting the environment variable `MMDB_ADDR`.
 This can be done, for instance, with
 [ModSecurity](https://github.com/SpiderLabs/ModSecurity/) in (real) phase 1.
-Note that mod_setenvif and mod_rewrite cannot be used for this as they are
-running after this module. For most usages,
+Note that mod_env, mod_setenvif and mod_rewrite cannot be used for this as they
+are running after this module. For most usages,
 [mod_remoteip](http://httpd.apache.org/docs/current/mod/mod_remoteip.html)
 is an easier alternative.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ your proxy frontend),
 [mod_remoteip](http://httpd.apache.org/docs/current/mod/mod_remoteip.html) may
 be used to set the client IP address.
 Manually setting the client IP address is also possible - see
-[Client IP address lookup control](client-ip-address-lookup-control).
+[Client IP address lookup control][ip-lookup-control].
 
 ## Directives ##
 
@@ -96,7 +96,7 @@ In addition to the environment variable specified by `MaxMindDBEnv`, this
 module exports `MMDB_ADDR`, which contains the IP address used for lookups by
 the module. This is primarily intended for debugging purposes.
 
-## Client IP address lookup control ##
+[ip-lookup-control]:## Client IP address lookup control ##
 
 In case you want supply your own value for the IP address to lookup, it may be
 done by setting the environment variable `MMDB_ADDR`.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ your proxy frontend),
 [mod_remoteip](http://httpd.apache.org/docs/current/mod/mod_remoteip.html) may
 be used to set the client IP address.
 Manually setting the client IP address is also possible - see
-[Client IP address lookup control][ip-lookup-control].
+[Client IP address lookup control](#client-ip-address-lookup-control).
 
 ## Directives ##
 
@@ -96,7 +96,7 @@ In addition to the environment variable specified by `MaxMindDBEnv`, this
 module exports `MMDB_ADDR`, which contains the IP address used for lookups by
 the module. This is primarily intended for debugging purposes.
 
-[ip-lookup-control]: ## Client IP address lookup control ##
+## Client IP address lookup control ##
 
 In case you want supply your own value for the IP address to lookup, it may be
 done by setting the environment variable `MMDB_ADDR`.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ In addition to the environment variable specified by `MaxMindDBEnv`, this
 module exports `MMDB_ADDR`, which contains the IP address used for lookups by
 the module. This is primarily intended for debugging purposes.
 
-[ip-lookup-control]:## Client IP address lookup control ##
+[ip-lookup-control]: ## Client IP address lookup control ##
 
 In case you want supply your own value for the IP address to lookup, it may be
 done by setting the environment variable `MMDB_ADDR`.

--- a/src/mod_maxminddb.c
+++ b/src/mod_maxminddb.c
@@ -315,6 +315,8 @@ static int export_env(request_rec *r, maxminddb_config *conf)
 
 static char *get_client_ip(request_rec *r)
 {
+    const char *addr = apr_table_get(r->subprocess_env, "MMDB_ADDR");
+    if (addr) return (char*)addr;
 # if AP_SERVER_MAJORVERSION_NUMBER == 2 && AP_SERVER_MINORVERSION_NUMBER == 4
     return r->useragent_ip;
 # else


### PR DESCRIPTION
This allows to use another mechanism than mod_remoteip to set the origin IP.
Typically, mod_security2 can be used (in phase 1).
Totally compatible with the current behaviour if this feature is not used.