### PR TITLE
Update README with Apache 2.4 block/allow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,35 @@ This example shows how to block users based on their country:
     MaxMindDBFile COUNTRY_DB /usr/local/share/GeoIP/GeoLite2-Country.mmdb
     MaxMindDBEnv MM_COUNTRY_CODE COUNTRY_DB/country/iso_code
 
-    SetEnvIf MM_COUNTRY_CODE ^(RU|DE|FR) BlockCountry
-    Deny from env=BlockCountry
+    <Directory /your/directory>
+        SetEnvIf MM_COUNTRY_CODE ^(RU|DE|FR) BlockCountry
+        <RequireAll>
+            Require env MM_COUNTRY_CODE
+            Require not env BlockCountry
+        </RequireAll>
+    </Directory>
 
-Note that at least the "Deny" or "Allow" directive (or "Require" directive in
-Apache 2.4 and above) must be applied within a `<Directory>`, `<Location>` or
-`<Files>` container.
+Note that the "Require" directive must be applied within a `<Directory>`,
+`<Location>` or `<Files>` container.
+
+### Allowing by Country ###
+
+This example shows how to allow users based on their country:
+
+    MaxMindDBEnable On
+    MaxMindDBFile COUNTRY_DB /usr/local/share/GeoIP/GeoLite2-Country.mmdb
+    MaxMindDBEnv MM_COUNTRY_CODE COUNTRY_DB/country/iso_code
+
+    <Directory /your/directory>
+        SetEnvIf MM_COUNTRY_CODE ^(CA|FR) AllowCountry
+        <RequireAll>
+            Require env MM_COUNTRY_CODE
+            Require env AllowCountry
+        </RequireAll>
+    </Directory>
+
+Note that the "Require" directive must be applied within a `<Directory>`,
+`<Location>` or `<Files>` container.
 
 ## Data Output Format ##
 


### PR DESCRIPTION
Apache 2.4 was released 13 years ago, and the previous release, Apache 2.2 has not had security support for seven years. With this in mind, I've updated the "Blocking by Country" example to use the `mod_authz_host` directives for access restrictions, which superseded `mod_access_compat` in Apache 2.4. I also added a "Allowing by Country" example to the README. I tested both of these configurations locally and they work as-expected.

Fixes #122 